### PR TITLE
Switch badgets for Rockets conditional components.

### DIFF
--- a/src/components/Rockets.js
+++ b/src/components/Rockets.js
@@ -32,6 +32,7 @@ function Rockets() {
               <h1 className="rocketTitle">{item.name}</h1>
 
               <p className="description">
+                {/* switch badgets for Rockets conditional components */}
                 {item.reserved && (<span className="msg">Reserved</span>)}
                 <span> </span>
                 {item.description}


### PR DESCRIPTION
Rockets that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design)